### PR TITLE
Adding media encodings query + 1 fix

### DIFF
--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -35,6 +35,13 @@ class Limelight
     end
   end
 
+  def events(options = {})
+    # http://api.videoplatform.limelight.com/rest/organizations/<org id>/events
+    path = generate_encoded_path('get', "#{@base_url}/events", options, @host)
+    response = @client.get(path)
+    JSON.parse response.body
+  end
+
   def media_info(media_id)
     response = @client.get("#{@base_media_url}/#{media_id}/properties.json")
     JSON.parse response.body

--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -56,6 +56,20 @@ class Limelight
     JSON.parse response.body
   end
 
+  def analytics_for_channels(start_time, end_time, options = {})
+    # http://api.videoplatform.limelight.com/rest/organizations/<org id>/analytics/performance/channels.{xml,json,csv}
+    params = {
+      :start => start_time,
+      :end => end_time
+    }
+
+    params.merge!(options)
+
+    path = generate_encoded_path('get', "#{@base_analytics_url}/performance/channels.json", params, @host)
+    response = @client.get(path)
+    JSON.parse response.body
+  end
+
   def media_engagement(start_time, end_time, options = {})
     params = {
       :start => start_time,

--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -207,9 +207,9 @@ class Limelight
     @client.delete(path)
   end
 
-  def list_channel_media(channel_id)
+  def list_channel_media(channel_id, options = {})
     # http://api.videoplatform.limelight.com/rest/organizations/<org id>/channels/<channel id>/media.{XML,JSON}
-    response = @client.get("#{@base_channels_url}/#{channel_id}/media.json")
+    response = @client.get("#{@base_channels_url}/#{channel_id}/media.json", options)
     JSON.parse response.body
   end
 

--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -48,6 +48,14 @@ class Limelight
   end
 
 
+  # skimming thumnails
+  def thumbnails(id)
+    params = {}
+    path = generate_encoded_path('get', "#{@base_media_url}/#{id}/skimming_thumbnails.json", params)
+    response = @client.get(path)
+    JSON.parse response.body
+  end
+
   # valid primary_use values are :all, :flash, :mobile264, :mobile3gp, :httplivestreaming
   # default value is :all
   def media_encodings(id, primary_use = :all)

--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -40,6 +40,18 @@ class Limelight
     JSON.parse response.body
   end
 
+
+  # valid primary_use values are :all, :flash, :mobile264, :mobile3gp, :httplivestreaming
+  # default value is :all
+  def media_encodings(id, primary_use = :all)
+    # http://api.videoplatform.limelight.com/rest/organizations/<org id>/media/<media id>/encodings.{XML,JSON}
+    params = {:primary_use => primary_use.to_s}
+
+    path = generate_encoded_path('get', "#{@base_media_url}/#{id}/encodings.json", params)
+    response = @client.get(path, params)
+    JSON.parse response.body
+  end
+
   def update_media(id, attributes)
     path = generate_encoded_path('put', "#{@base_media_url}/#{id}/properties")
     response = @client.put(path, attributes)

--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -48,7 +48,7 @@ class Limelight
     params = {:primary_use => primary_use.to_s}
 
     path = generate_encoded_path('get', "#{@base_media_url}/#{id}/encodings.json", params)
-    response = @client.get(path, params)
+    response = @client.get(path)
     JSON.parse response.body
   end
 

--- a/limelight_video.gemspec
+++ b/limelight_video.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "limelight_video"
-  s.version           = "0.0.4"
+  s.version           = "0.0.5"
   s.summary           = "Limelight video client"
   s.description       = "Interact with the Limelight CDN platform"
   s.authors           = ["elcuervo"]

--- a/test/fixtures/cassettes/channel_statistics_load.yml
+++ b/test/fixtures/cassettes/channel_statistics_load.yml
@@ -1,0 +1,44 @@
+--- 
+http_interactions: 
+- request: 
+    method: get
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/analytics/performance/channels.json?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&end=1362114000&expires=1362771230&signature=CK2HaTkxmnLVI%2BQxM%2ByjRRw8C2AIlXc8A1eWWdXUMJ8%3D&start=1359694800
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      user-agent: 
+      - Faraday v0.8.6
+      accept-encoding: 
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      accept: 
+      - "*/*"
+      connection: 
+      - close
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      server: 
+      - nginx/0.8.54
+      date: 
+      - Fri, 08 Mar 2013 19:29:02 GMT
+      content-type: 
+      - application/json;charset=UTF-8
+      connection: 
+      - close
+      access-control-allow-origin: 
+      - "*"
+      cache-control: 
+      - max-age=300,max-stale=18000, public
+      etag: 
+      - "\"80a3c37734c647a2ae2c3b713541d85b\""
+      content-length: 
+      - "68"
+    body: 
+      encoding: US-ASCII
+      string: "{\"has_next\":false,\"data_as_of\":1362770941,\"page_id\":0,\"channels\":[]}"
+    http_version: "1.1"
+  recorded_at: Fri, 08 Mar 2013 19:28:52 GMT
+recorded_with: VCR 2.1.1

--- a/test/fixtures/cassettes/events_load.yml
+++ b/test/fixtures/cassettes/events_load.yml
@@ -1,0 +1,38 @@
+--- 
+http_interactions: 
+- request: 
+    method: get
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/events?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363895866&signature=mEy1%2B3%2BlnK2VBaYOac8lnO6s8L8sflBFqCZIPF3oCoU%3D
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      user-agent: 
+      - Faraday v0.8.6
+      accept-encoding: 
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      accept: 
+      - "*/*"
+      connection: 
+      - close
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      server: 
+      - nginx/0.8.54
+      date: 
+      - Thu, 21 Mar 2013 19:52:51 GMT
+      content-type: 
+      - application/json
+      connection: 
+      - close
+      content-length: 
+      - "5820"
+    body: 
+      encoding: US-ASCII
+      string: "{\"data_as_of\":1363895571,\"has_next\":false,\"page_id\":0,\"event_list\":[{\"event_type\":\"MEDIA_CREATED\",\"event_id\":\"98f924e5d2b0455688161e487f595873\",\"event_timestamp\":1362669513,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample.mp4\",\"upload_method\":\"unknown\",\"media_id\":\"7a504e2a240f49e084825482902ae91f\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"08dd18b303454f6299995404c1fc11a7\",\"event_timestamp\":1362669513,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"7a504e2a240f49e084825482902ae91f\",\"property\":\"Title\"}},{\"event_type\":\"CHANNEL_CREATED\",\"event_id\":\"0d1bd001ec824a9c84e57286e42a5c2b\",\"event_timestamp\":1362669514,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"title\":\"new_channel\",\"channel_id\":\"a1803fd4dca34954860a9233fc966cd4\"}},{\"event_type\":\"CHANNEL_METADATA_MODIFIED\",\"event_id\":\"03d20a269dfd4e7bb2fb928dcee811a2\",\"event_timestamp\":1362669515,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"channel_id\":\"a1803fd4dca34954860a9233fc966cd4\",\"property\":\"State\"}},{\"event_type\":\"CHANNEL_CONTENTS_MODIFIED\",\"event_id\":\"51831c432a264ea4aaba1db2e78f31a9\",\"event_timestamp\":1362669516,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"channel_id\":\"a1803fd4dca34954860a9233fc966cd4\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"52f699fc28bb41eea231611dcfe37fce\",\"event_timestamp\":1362669642,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"7a504e2a240f49e084825482902ae91f\",\"property\":\"Thumbnail\"}},{\"event_type\":\"MEDIA_PROCESSING_SUCCESS\",\"event_id\":\"b36c8155f3984b9690c42e98fc0207f7\",\"event_timestamp\":1362669667,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample-mp4\",\"media_id\":\"7a504e2a240f49e084825482902ae91f\"}},{\"event_type\":\"MEDIA_CREATED\",\"event_id\":\"a81df1f5c515495bbbe917d1b39cbad7\",\"event_timestamp\":1362670953,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample.mp4\",\"upload_method\":\"unknown\",\"media_id\":\"f1e9a8a30c3547a8b010a1c048ac4915\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"8b79e675d39a4123b5fe1261e81886ac\",\"event_timestamp\":1362670954,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"f1e9a8a30c3547a8b010a1c048ac4915\",\"property\":\"Title\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"70c11ae68e9e4bdeb027908acb7093aa\",\"event_timestamp\":1362671132,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"f1e9a8a30c3547a8b010a1c048ac4915\",\"property\":\"Thumbnail\"}},{\"event_type\":\"MEDIA_PROCESSING_SUCCESS\",\"event_id\":\"fb79fed720a74574b5f305f1fec0e26a\",\"event_timestamp\":1362671156,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample-mp4\",\"media_id\":\"f1e9a8a30c3547a8b010a1c048ac4915\"}},{\"event_type\":\"MEDIA_CREATED\",\"event_id\":\"4a9c23a1b9e84a74a0ed242e1032fcb7\",\"event_timestamp\":1363015193,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample.mp4\",\"upload_method\":\"unknown\",\"media_id\":\"23b0805499164f5cbd28134a07bec56d\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"7ec6a71ea8484c149cd02f0d2bcd09da\",\"event_timestamp\":1363015193,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"23b0805499164f5cbd28134a07bec56d\",\"property\":\"Title\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"cd4c764141154fd9a7d25e756a4d53c7\",\"event_timestamp\":1363015234,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"23b0805499164f5cbd28134a07bec56d\",\"property\":\"Thumbnail\"}},{\"event_type\":\"MEDIA_PROCESSING_SUCCESS\",\"event_id\":\"3979d3e10b4b4f3aacc45a5821df9de4\",\"event_timestamp\":1363015250,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample-mp4\",\"media_id\":\"23b0805499164f5cbd28134a07bec56d\"}},{\"event_type\":\"MEDIA_CREATED\",\"event_id\":\"4e2734a150b24052b6825a1b64e898a2\",\"event_timestamp\":1363016014,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample.mp4\",\"upload_method\":\"unknown\",\"media_id\":\"dd60ec8341bf48c1bd4be4532b946525\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"e7d5c280ed52464995643b7e50439bf4\",\"event_timestamp\":1363016014,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"dd60ec8341bf48c1bd4be4532b946525\",\"property\":\"Title\"}},{\"event_type\":\"MEDIA_CREATED\",\"event_id\":\"b7c3478407eb4f5484a48e14d361d663\",\"event_timestamp\":1363016091,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample.mp4\",\"upload_method\":\"unknown\",\"media_id\":\"42d781877900454ab24f5d7cdc5ebf86\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"e154a4285016489282d6c00a8de6fa34\",\"event_timestamp\":1363016091,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"42d781877900454ab24f5d7cdc5ebf86\",\"property\":\"Title\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"dd2091d1dd8a4c5d84f23263644455d1\",\"event_timestamp\":1363016135,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"42d781877900454ab24f5d7cdc5ebf86\",\"property\":\"Thumbnail\"}},{\"event_type\":\"MEDIA_METADATA_MODIFIED\",\"event_id\":\"d70b12c1bc514b13a49f4f44be6f71c0\",\"event_timestamp\":1363016139,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"media_id\":\"dd60ec8341bf48c1bd4be4532b946525\",\"property\":\"Thumbnail\"}},{\"event_type\":\"MEDIA_PROCESSING_SUCCESS\",\"event_id\":\"a65da364cf3d4d0b8acc0f52267943fc\",\"event_timestamp\":1363016156,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample-mp4\",\"media_id\":\"dd60ec8341bf48c1bd4be4532b946525\"}},{\"event_type\":\"MEDIA_PROCESSING_SUCCESS\",\"event_id\":\"e380b59bff9441748638f02ab0481fbc\",\"event_timestamp\":1363016158,\"org_id\":\"dde8e72013ba44768e764e1bff217a5a\",\"properties\":{\"original_filename\":\"sample-mp4\",\"media_id\":\"42d781877900454ab24f5d7cdc5ebf86\"}}]}"
+    http_version: "1.1"
+  recorded_at: Thu, 21 Mar 2013 19:52:47 GMT
+recorded_with: VCR 2.1.1

--- a/test/fixtures/cassettes/media_encodings_load.yml
+++ b/test/fixtures/cassettes/media_encodings_load.yml
@@ -2,7 +2,7 @@
 http_interactions: 
 - request: 
     method: post
-    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016307&signature=djIgBeq7yWisu7w8zia9ZVicepbL4ZOhCkP%2BHjfvuss%3D
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016384&signature=cDsJDJrdUdbdsxZvgS9FOIspmH9ZXFzIPY8Nx01ZdpE%3D
     body: 
       encoding: US-ASCII
       string: ""
@@ -25,7 +25,7 @@ http_interactions:
       server: 
       - nginx/0.8.54
       date: 
-      - Mon, 11 Mar 2013 15:33:35 GMT
+      - Mon, 11 Mar 2013 15:34:52 GMT
       content-type: 
       - application/json; charset=utf-8
       connection: 
@@ -35,19 +35,19 @@ http_interactions:
       status: 
       - 201 Created
       x-runtime: 
-      - 1341ms
+      - 1437ms
       content-length: 
       - "747"
       via: 
-      - 1.0 vps-099.iad.llnw.net
+      - 1.0 vps-162.iad.llnw.net
     body: 
       encoding: US-ASCII
-      string: "{\"publish_date\": null, \"category\": null, \"description\": null, \"sched_end_date\": null, \"tags\": [], \"title\": \"test\", \"media_id\": \"dd60ec8341bf48c1bd4be4532b946525\", \"media_type\": \"Video\", \"original_filename\": \"sample-mp4\", \"sched_start_date\": null, \"restrictionrule_id\": null, \"create_date\": 1363016014, \"state\": \"New\", \"total_storage_in_bytes\": 0, \"thumbnails\": [{\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}, {\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}], \"ref_id\": null, \"update_date\": 1363016014, \"custom_property\": null, \"duration_in_milliseconds\": 0}"
+      string: "{\"publish_date\": null, \"category\": null, \"description\": null, \"sched_end_date\": null, \"tags\": [], \"title\": \"test\", \"media_id\": \"42d781877900454ab24f5d7cdc5ebf86\", \"media_type\": \"Video\", \"original_filename\": \"sample-mp4\", \"sched_start_date\": null, \"restrictionrule_id\": null, \"create_date\": 1363016091, \"state\": \"New\", \"total_storage_in_bytes\": 0, \"thumbnails\": [{\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}, {\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}], \"ref_id\": null, \"update_date\": 1363016091, \"custom_property\": null, \"duration_in_milliseconds\": 0}"
     http_version: "1.1"
-  recorded_at: Mon, 11 Mar 2013 15:33:29 GMT
+  recorded_at: Mon, 11 Mar 2013 15:34:46 GMT
 - request: 
     method: get
-    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media/dd60ec8341bf48c1bd4be4532b946525/encodings.json?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016309&primary_use=all&signature=zZPDc5QCVI3YiGke8wV5lQbehS8pEaDIabg6W03vZak%3D
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media/42d781877900454ab24f5d7cdc5ebf86/encodings.json?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016386&primary_use=all&signature=BnLsY%2FlCnTO4KnKMaHmxipvEgL8q3I3eHqZdL2KzW%2BM%3D
     body: 
       encoding: US-ASCII
       string: ""
@@ -68,7 +68,7 @@ http_interactions:
       server: 
       - nginx/0.8.54
       date: 
-      - Mon, 11 Mar 2013 15:33:35 GMT
+      - Mon, 11 Mar 2013 15:34:52 GMT
       content-type: 
       - application/json;charset=UTF-8
       connection: 
@@ -78,12 +78,12 @@ http_interactions:
       cache-control: 
       - max-age=300,max-stale=18000, public
       etag: 
-      - "\"6a2c92bbe9b14263b7b0755075167342\""
+      - "\"c2683d816c8945dfa9cf398eb846921c\""
       content-length: 
       - "76"
     body: 
       encoding: US-ASCII
       string: "{\"errors\": [\"Media either does not exist or you do not have access to it.\"]}"
     http_version: "1.1"
-  recorded_at: Mon, 11 Mar 2013 15:33:29 GMT
+  recorded_at: Mon, 11 Mar 2013 15:34:46 GMT
 recorded_with: VCR 2.1.1

--- a/test/fixtures/cassettes/media_encodings_load.yml
+++ b/test/fixtures/cassettes/media_encodings_load.yml
@@ -1,0 +1,89 @@
+--- 
+http_interactions: 
+- request: 
+    method: post
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016307&signature=djIgBeq7yWisu7w8zia9ZVicepbL4ZOhCkP%2BHjfvuss%3D
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      user-agent: 
+      - Faraday v0.8.6
+      content-type: 
+      - multipart/form-data;boundary=-----------RubyMultipartPost
+      content-length: 
+      - "246148"
+      accept: 
+      - "*/*"
+      connection: 
+      - close
+  response: 
+    status: 
+      code: 201
+      message: Created
+    headers: 
+      server: 
+      - nginx/0.8.54
+      date: 
+      - Mon, 11 Mar 2013 15:33:35 GMT
+      content-type: 
+      - application/json; charset=utf-8
+      connection: 
+      - close
+      cache-control: 
+      - no-cache
+      status: 
+      - 201 Created
+      x-runtime: 
+      - 1341ms
+      content-length: 
+      - "747"
+      via: 
+      - 1.0 vps-099.iad.llnw.net
+    body: 
+      encoding: US-ASCII
+      string: "{\"publish_date\": null, \"category\": null, \"description\": null, \"sched_end_date\": null, \"tags\": [], \"title\": \"test\", \"media_id\": \"dd60ec8341bf48c1bd4be4532b946525\", \"media_type\": \"Video\", \"original_filename\": \"sample-mp4\", \"sched_start_date\": null, \"restrictionrule_id\": null, \"create_date\": 1363016014, \"state\": \"New\", \"total_storage_in_bytes\": 0, \"thumbnails\": [{\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}, {\"url\": \"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf\", \"width\": \"\", \"height\": \"\"}], \"ref_id\": null, \"update_date\": 1363016014, \"custom_property\": null, \"duration_in_milliseconds\": 0}"
+    http_version: "1.1"
+  recorded_at: Mon, 11 Mar 2013 15:33:29 GMT
+- request: 
+    method: get
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media/dd60ec8341bf48c1bd4be4532b946525/encodings.json?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1363016309&primary_use=all&signature=zZPDc5QCVI3YiGke8wV5lQbehS8pEaDIabg6W03vZak%3D
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      user-agent: 
+      - Faraday v0.8.6
+      accept-encoding: 
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      accept: 
+      - "*/*"
+      connection: 
+      - close
+  response: 
+    status: 
+      code: 400
+      message: Bad Request
+    headers: 
+      server: 
+      - nginx/0.8.54
+      date: 
+      - Mon, 11 Mar 2013 15:33:35 GMT
+      content-type: 
+      - application/json;charset=UTF-8
+      connection: 
+      - close
+      access-control-allow-origin: 
+      - "*"
+      cache-control: 
+      - max-age=300,max-stale=18000, public
+      etag: 
+      - "\"6a2c92bbe9b14263b7b0755075167342\""
+      content-length: 
+      - "76"
+    body: 
+      encoding: US-ASCII
+      string: "{\"errors\": [\"Media either does not exist or you do not have access to it.\"]}"
+    http_version: "1.1"
+  recorded_at: Mon, 11 Mar 2013 15:33:29 GMT
+recorded_with: VCR 2.1.1

--- a/test/fixtures/cassettes/skimming_thumbnails.yml
+++ b/test/fixtures/cassettes/skimming_thumbnails.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1410969910&signature=ZqFNel6zbAU%2BKOBigYCW3NTc%2Be7mGsDicGM0QR%2Fa%2FDU%3D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - Faraday v0.9.0
+      content-type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost
+      content-length:
+      - '248212'
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      accept:
+      - '*/*'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300,max-stale=18000,public
+      content-length:
+      - '755'
+      content-type:
+      - application/json;charset=UTF-8
+      date:
+      - Wed, 17 Sep 2014 16:00:09 GMT
+      etag:
+      - '"c7d8b3eb114248bdb8cc40915396fdd6"'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"publish_date":null,"category":null,"description":null,"sched_end_date":null,"tags":[],"title":"test","media_id":"73ff843a699d4bb09ec256324ca0bee8","media_type":"Video","original_filename":"test","sched_start_date":null,"restrictionrule_id":null,"create_date":1410969607,"state":"Uploading","total_storage_in_bytes":0,"allow_ads":true,"thumbnails":[{"url":"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf","width":"","height":""},{"url":"http://img.delvenetworks.com/0000000000000000000000/0000000000000000000000/defaultVideoPreviewImage.swf","width":"","height":""}],"ref_id":null,"update_date":1410969607,"custom_property":{},"duration_in_milliseconds":0,"closed_captions_url":null,"captions":[]}'
+    http_version: '1.1'
+  recorded_at: Wed, 17 Sep 2014 16:00:12 GMT
+- request:
+    method: get
+    uri: http://api.videoplatform.limelight.com/rest/organizations/dde8e72013ba44768e764e1bff217a5a/media/73ff843a699d4bb09ec256324ca0bee8/skimming_thumbnails.json?access_key=DaYkT4MO0DwIdTk1Af9XmHFHFGM%3D&expires=1410969912&signature=3sTe3TSZx8uryI6ckQdt95EXtyrOfJXy4G7IuDYHKIM%3D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - Faraday v0.9.0
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300,max-stale=18000, public
+      date:
+      - Wed, 17 Sep 2014 16:00:09 GMT
+      etag:
+      - '"19de711cfaa4497498ee29c097ed2548"'
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '228'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"has_next":false,"data_as_of":1410969609,"page_id":0,"thumbnail_list":[{"index":0,"time_in_milliseconds":0,"width":120,"height":0,"url":"http://cpc.delvenetworks.com/3ejnIBO6RHYjnZOG_8helo/c_-EOmmdS7AnsJWMkygvug/skim/0.jpeg"}]}'
+    http_version: '1.1'
+  recorded_at: Wed, 17 Sep 2014 16:00:13 GMT
+recorded_with: VCR 2.9.3

--- a/test/integration/limelight_test.rb
+++ b/test/integration/limelight_test.rb
@@ -158,4 +158,13 @@ describe Limelight do
       # channel until it's been processed on the Limelight Platform
     end
   end
+
+  it "should get a list of events" do
+    with_a_cassette("events load") do
+      @events = @limelight.events
+
+      assert @events.include?("event_list")
+      assert @events["event_list"].class == Array
+    end
+  end
 end

--- a/test/integration/limelight_test.rb
+++ b/test/integration/limelight_test.rb
@@ -65,6 +65,13 @@ describe Limelight do
     end
   end
 
+  it 'should get encoding details for specific media' do
+    with_a_cassette('media encodings load') do
+      video = @limelight.upload(sample_mp4_file, title: 'test')
+      encodings = @limelight.media_encodings(video["media_id"])
+    end
+  end
+
   it 'should create a channel' do
     with_a_cassette('create a channel') do
       channel = @limelight.create_channel('test')

--- a/test/integration/limelight_test.rb
+++ b/test/integration/limelight_test.rb
@@ -167,4 +167,13 @@ describe Limelight do
       assert @events["event_list"].class == Array
     end
   end
+
+  it "should retrieve skimming thumbnails" do
+    with_a_cassette("skimming thumbnails") do
+      video = @limelight.upload(sample_mp4_file, title: 'test')
+
+      @thumbnails = @limelight.thumbnails(video["media_id"])
+    end      
+  end
+
 end

--- a/test/integration/limelight_test.rb
+++ b/test/integration/limelight_test.rb
@@ -99,6 +99,15 @@ describe Limelight do
     end
   end
 
+  it "should get statistics for channels" do
+    with_a_cassette('channel statistics load') do
+      start_time = Date.new(2013,2,1).to_time.to_i    
+      end_time = Date.new(2013,3,1).to_time.to_i
+
+      statistics = @limelight.analytics_for_channels(start_time, end_time)
+    end
+  end
+
   it "should get media statistics" do
     with_a_cassette('media statistics load') do
       video = @limelight.upload(sample_mp4_file, title: 'test')


### PR DESCRIPTION
Added the ability to query media encodings with #media_encodings method.

Limelight API now paginates data in order to increase return speed. #list_channel_media, therefore, was not pulling in all media.  I have updated the method to add additional optional arguments of page_size and page_id in order to support pagination.

Added #analytics_for_channel method for pulling up channel analytics including total play time.

There will probably be other pull requests as our usage needs increase. Please let me know if you would like these to be handled differently.
