### PR TITLE
Allow to specify the ref_id property when uploading the media.

### DIFF
--- a/lib/limelight_video.rb
+++ b/lib/limelight_video.rb
@@ -101,6 +101,7 @@ class Limelight
     media_file = Faraday::UploadIO.new(file, mime, filename)
     options = {
       title: attributes.fetch(:title, 'Unnamed'),
+      ref_id: attributes.fetch(:ref_id, ''),
       media_file: media_file
     }
     if attributes[:metadata]

--- a/test/integration/limelight_test.rb
+++ b/test/integration/limelight_test.rb
@@ -20,6 +20,13 @@ describe Limelight do
     end
   end
 
+  it 'should specify the ref_id property for the uploading media' do
+    with_a_cassette("limelight upload media") do
+      video = @limelight.upload(sample_mp4_file, ref_id: '32')
+      video["ref_id"].must_equal '32'
+    end
+  end
+
   it 'should upload an io stream' do
     with_a_cassette("limelight upload io") do
       io = StringIO.new << File.read(sample_mp4_file)


### PR DESCRIPTION
Apparently, the `ref_id` isn't being taken by Limelight when passed in this format: `custom_property[<custom_property_name>] = <custom_property_value>`. Now it can be specified directly in the upload attributes hash:

``` ruby
limelight.upload(path_to_file, title: 'Personal Jesus', ref_id: '32')
```
